### PR TITLE
feat: add language switcher

### DIFF
--- a/src/routes/+layout.server.js
+++ b/src/routes/+layout.server.js
@@ -1,7 +1,8 @@
 /** @type {import('./$types').PageLoad} */
 export const prerender = true;
 
-export async function load({params}) {
-    const response = await fetch('https://resume-back.vercel.app/resume/1');
+export async function load({ url, fetch }) {
+    const language = url.searchParams.get('language') ?? 'en';
+    const response = await fetch(`https://resume-back.vercel.app/resume/1?language=${language}`);
     return await response.json();
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,11 +2,31 @@
 
 import Profile from '$lib/Profile.svelte'
 import History from '$lib/History.svelte'
+import { goto } from '$app/navigation'
+import { page } from '$app/stores'
 
-/** @type {import('./$types').PageData} */    export let data;
+/** @type {import('./$types').PageData} */ export let data;
+
+/** @type {string} */
+let language
+$: language = $page.url.searchParams.get('language') || 'en'
+
+/**
+ * @param {Event} event
+ */
+function switchLanguage(event) {
+    const select = /** @type {HTMLSelectElement} */ (event.target)
+    goto(`/?language=${select.value}`)
+}
 </script>
 <body itemscope="itemscope" itemtype="http://schema.org/Person">
 <div class="container-fluid">
+    <div class="language-switcher text-end p-2">
+        <select on:change={switchLanguage} bind:value={language}>
+            <option value="en">English</option>
+            <option value="pt">Português</option>
+        </select>
+    </div>
     <div class="row main clearfix"><a class="js-floating-nav-trigger floating-nav-trigger" href="#"><i
         class="icon-bars"></i><span class="close-icon">×</span></a>
         <nav class="floating-nav js-floating-nav">


### PR DESCRIPTION
## Summary
- allow selecting English or Portuguese on the resume page
- forward selected language to backend when loading resume data

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check` *(fails: Type 'string' is not assignable to type 'boolean | null | undefined'. (js))*

------
https://chatgpt.com/codex/tasks/task_e_68b66276d3908327aad44ed70a18e7f3